### PR TITLE
add NamedLock

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ with lock:
 
 ```
 
+A `NamedLock` will save the lock file to shared memory using [memory-tempfile](https://github.com/mbello/memory-tempfile)
+
+```python
+from combo_lock import NamedLock
+
+lock = NamedLock('some_name')
+
+with lock:
+    write_my_shared_resource()
+```
+
 ### History
 
 The combo-lock was originally created for [Mycroft-core](https://github.com/mycroftai/mycroft-core) but as it's been useful in other projects a separate release seemed appropriate.

--- a/combo_lock/__init__.py
+++ b/combo_lock/__init__.py
@@ -1,9 +1,9 @@
-from .combo_lock import ComboLock
+from .combo_lock import ComboLock, NamedLock
 
-
-VERSION = "0.1.0"
+VERSION = "0.1.1"
 
 __all__ = [
+    NamedLock,
     ComboLock,
     VERSION
 ]

--- a/combo_lock/combo_lock.py
+++ b/combo_lock/combo_lock.py
@@ -14,8 +14,9 @@
 #
 from threading import Lock
 from fasteners.process_lock import InterProcessLock
-from os.path import exists
+from os.path import exists, join
 from os import chmod
+from combo_lock.util import get_ram_directory
 
 
 class ComboLock:
@@ -72,3 +73,10 @@ class ComboLock:
     def __exit__(self, _type, value, traceback):
         """ Releases the lock. """
         self.release()
+
+
+class NamedLock(ComboLock):
+    def __init__(self, name):
+        path = join(get_ram_directory("combo_locks"), name + ".lock")
+        super().__init__(path)
+        self.name = name

--- a/combo_lock/util.py
+++ b/combo_lock/util.py
@@ -1,0 +1,11 @@
+from memory_tempfile import MemoryTempfile
+import os
+
+
+def get_ram_directory(folder):
+    tempfile = MemoryTempfile(fallback=True)
+    path = os.path.join(tempfile.gettempdir(), folder)
+    if not os.path.exists(path):
+        os.makedirs(path)
+    return path
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 fasteners~=0.16
+memory-tempfile

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def required(requirements_file):
 
 setup(
     name='Combo Lock',
-    version='0.1.0',
+    version='0.1.1',
     packages=['combo_lock'],
     package_data={
       '*': ['*.txt', '*.md']


### PR DESCRIPTION
A `NamedLock` will save the lock file to shared memory using [memory-tempfile](https://github.com/mbello/memory-tempfile)

```python
from combo_lock import NamedLock

lock = NamedLock('some_name')

with lock:
    write_my_shared_resource()
```