### PR TITLE
post_release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ def required(requirements_file):
 
 
 setup(
-    name='Combo Lock',
-    version='0.1.1',
+    name='combo_lock',
+    version='0.1.1post1',
     packages=['combo_lock'],
     package_data={
       '*': ['*.txt', '*.md']


### PR DESCRIPTION
the previous version (0.0.1) was published as `combo_lock`, the new release is called `Combo Lock`

this PR renames it back, i have also yanked the 0.0.1 release from pypi

NOTE: i am unable to install `Combo Lock` at all, pypi says `pip install Combo-Lock` should work, but it does not (in requirements.txt at least)