### PR TITLE
Use base64 url and filename safe encoding as filename for named lock

### DIFF
--- a/combo_lock/combo_lock.py
+++ b/combo_lock/combo_lock.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from base64 import b64encode
 from threading import Lock
 from fasteners.process_lock import InterProcessLock
 from os.path import exists, join
@@ -75,8 +76,22 @@ class ComboLock:
         self.release()
 
 
+def _filename_from_name(name):
+    """Create a filesystem safe filename from name.
+
+    Arguments:
+        name (string): name to encode
+
+    Returns:
+        (string) encoded version of the name.
+    """
+    encoded_name = b64encode(name.encode(), altchars=b'-_')
+    return encoded_name.decode() + ".lock"
+
+
 class NamedLock(ComboLock):
     def __init__(self, name):
-        path = join(get_ram_directory("combo_locks"), name + ".lock")
+        filename = _filename_from_name(name)
+        path = join(get_ram_directory("combo_locks"), filename)
         super().__init__(path)
         self.name = name

--- a/tests/test_named_lock.py
+++ b/tests/test_named_lock.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+
+from combo_lock import NamedLock
+
+class TestNamedLock(TestCase):
+    def test_simple_name(self):
+        lock = NamedLock('test_lock')
+        with lock:
+            pass
+
+    def test_name_with_slash(self):
+        lock = NamedLock('test/lock')
+        with lock:
+            pass
+
+    def test_name_with_emoji(self):
+        lock = NamedLock('💖🔒')
+        with lock:
+            pass


### PR DESCRIPTION
This will allow strings with weird characters, including paths to be used as names for NamedLock instances. Implementation uses the sha1 hex-digest of the name as filename. Resolves #5