### PR TITLE
Fix shared lock files

### DIFF
--- a/combo_lock/combo_lock.py
+++ b/combo_lock/combo_lock.py
@@ -14,7 +14,6 @@
 #
 from base64 import b64encode
 from threading import Lock
-from fasteners.process_lock import InterProcessLock
 from os.path import exists, join
 from os import chmod
 from combo_lock.util import get_ram_directory

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-fasteners~=0.16
+filelock~=3.2.0
 memory-tempfile

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -66,6 +66,7 @@ class TestComboLock(TestCase):
             lock = ComboLock(lock_file)
             success = lock.acquire(False)
             results[idx] = success
+            time.sleep(5)  # Keep the lock held until all threads have run
 
         for i in range(0, 10):
             Thread(target=_test_acquire, args=(i,), daemon=True).start()


### PR DESCRIPTION
#### Description
Closes #7 
Replaces InterProcessLock with FileLock to provide support for multiple lock instances sharing the same lock file.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
`test_multi_lock_acquire` provides a unit test for the bug described in #7. All existing unit tests pass and no entry points have changed.

#### Documentation
No changes to existing interfaces, only modifies underlying methods.