### PR TITLE
Make filelock requirement accept any compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-filelock~=3.2.0
+filelock~=3.2
 memory-tempfile


### PR DESCRIPTION
This should allow usage of filelock versions compatible with 3.2 (>=3.2 and < 4.0)

This should reslove #9, atleast pip doesn't complain about incompatible versions. @PureTryOut can you verify before we merge and release?