### PR TITLE
Loosen filelock requirement

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE.md
 include requirements.txt
+include requirements-old.txt
 include test/test.conf

--- a/requirements-old.txt
+++ b/requirements-old.txt
@@ -1,0 +1,2 @@
+filelock~=3.2.1
+memory-tempfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-filelock~=3.2
+filelock~=3.0
 memory-tempfile

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ def required(requirements_file):
 
 setup(
     name='combo_lock',
-    version='0.2.1',
+    version='0.2.2',
     packages=['combo_lock'],
     package_data={
       '*': ['*.txt', '*.md']

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@
 # under the License.
 
 import os
+import sys
 from setuptools import setup
 
 
@@ -28,13 +29,21 @@ with open("README.md", "r") as fh:
     long_desc = fh.read()
 
 
-def required(requirements_file):
+def load_requirements(requirements_file):
     """ Read requirements file and remove comments and empty lines. """
     base_dir = os.path.abspath(os.path.dirname(__file__))
     with open(os.path.join(base_dir, requirements_file), 'r') as f:
         requirements = f.read().splitlines()
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
+
+
+def required():
+    """Load appropriate requirements file."""
+    if sys.version_info[:2] > (3, 6):
+        return load_requirements("requirements.txt")
+    else:
+        return load_requirements("requirements-old.txt")
 
 
 setup(
@@ -45,7 +54,7 @@ setup(
       '*': ['*.txt', '*.md']
     },
     include_package_data=True,
-    install_requires=required('requirements.txt'),
+    install_requires=required(),
     url='https://github.com/forslund/combo-lock',
     license='Apache-2.0',
     author='Åke Forslund, JarbasAI',


### PR DESCRIPTION
Tests still pass with filelock 3.0 and _may_ resolve an issue experienced in
json-database 0.7.0 (which depends on combo-lock)

This also fixes setup with python 3.5 / 6 where newer versions of filelock would cause issues