### PR TITLE
Update util.py

### DIFF
--- a/combo_lock/util.py
+++ b/combo_lock/util.py
@@ -5,7 +5,6 @@ import os
 def get_ram_directory(folder):
     tempfile = MemoryTempfile(fallback=True)
     path = os.path.join(tempfile.gettempdir(), folder)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 


### PR DESCRIPTION
fix potential race condition if directory is created by external process after evaluation of the condition but before the path creation

this is a hard one to trigger, but was reported in ovos chat

```
==> logs/audio.log <==
2022-10-02 21:39:17.551 - OVOS - ovos_utils.configuration:<module>:52 - WARNING - configuration moved to the `ovos_config` package. This submodule will be removed in ovos_utils 0.1.0

[Errno 17] File exists: '/run/user/1000/combo_locks'
Traceback (most recent call last):
  File "/home/snow/ovos/lib/python3.9/site-packages/combo_lock/combo_lock.py", line 100, in __init__
    path = join(get_ram_directory("combo_locks"), filename)
  File "/home/snow/ovos/lib/python3.9/site-packages/combo_lock/util.py", line 9, in get_ram_directory
    os.makedirs(path)
  File "/usr/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/run/user/1000/combo_locks'

```