### PR TITLE
get_ram_directory() for non-linux os's

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -11,7 +11,7 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
+  build-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -37,10 +37,37 @@ jobs:
     - name: Tests
       run: pytest tests
 
+  build-mac-os-x:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python setup.py install
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=79 --statistics
+    - name: Tests
+      run: pytest tests
+
+
   publish:
     runs-on: ubuntu-latest
     if: contains(github.ref, '/tags/v')
-    needs: build
+    needs: build-linux
     steps:
     - uses: actions/checkout@v3
     - name: Push to pypi

--- a/combo_lock/util.py
+++ b/combo_lock/util.py
@@ -1,10 +1,16 @@
-from memory_tempfile import MemoryTempfile
 import os
+import platform
+import tempfile
 
+from memory_tempfile import MemoryTempfile
 
 def get_ram_directory(folder):
-    tempfile = MemoryTempfile(fallback=True)
-    path = os.path.join(tempfile.gettempdir(), folder)
+    """ Fallback to a regular temp directory on unsupported platforms. """
+    if platform.system() == "Linux":
+        temp_dir = MemoryTempfile(fallback=True).gettempdir()
+    else:
+        temp_dir = tempfile.gettempdir()
+    path = os.path.join(temp_dir, folder)
     os.makedirs(path, exist_ok=True)
     return path
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,9 @@
+from unittest import TestCase
+
+from combo_lock.util import get_ram_directory
+
+
+class TestComboLock(TestCase):
+    def test_ram_dir(self):
+        ram_dir = get_ram_directory("combo_locks")
+        assert(ram_dir is not None)


### PR DESCRIPTION
`MemoryTempfile` doesn't support non-linux systems at all causing exceptions since the class doesn't get setup at all. This is a hard fallback to tempdir() in these cases. This should resolve #19 

In addition a job for testing on Mac os-X has been added to verify this functionality.