### PR TITLE
Ensure ram directory and lock files are globally accessible

### DIFF
--- a/combo_lock/combo_lock.py
+++ b/combo_lock/combo_lock.py
@@ -14,9 +14,9 @@
 #
 from base64 import b64encode
 from threading import Lock
+from os import chmod
 from os.path import exists, join, dirname
-from os import chmod, makedirs
-from combo_lock.util import get_ram_directory
+from combo_lock.util import get_ram_directory, make_dir_with_global_permissions
 from filelock import FileLock, Timeout
 
 
@@ -121,6 +121,6 @@ class NamedLock(ComboLock):
             logging.getLogger("combo_lock").exception(e)
             path = join(gettempdir(), "combo_locks", filename)
             if not exists(dirname(path)):
-                makedirs(dirname(path), exist_ok=True)
+                make_dir_with_global_permissions(dirname(path))
         super().__init__(path)
         self.name = name

--- a/combo_lock/combo_lock.py
+++ b/combo_lock/combo_lock.py
@@ -19,6 +19,7 @@ from os.path import exists, join, dirname
 from combo_lock.util import get_ram_directory, make_dir_with_global_permissions
 from filelock import FileLock, Timeout
 
+LOCK_FILE_ACCESS_RIGHTS = 0o666
 
 class ComboLock:
     """ A combined process and thread lock.
@@ -31,7 +32,7 @@ class ComboLock:
         # all users to lock/unlock
         self.path = path
         self._init_plock_file()
-        self.plock = FileLock(path)
+        self.plock = FileLock(path, mode=LOCK_FILE_ACCESS_RIGHTS)
         self.tlock = Lock()
 
     def _init_plock_file(self):
@@ -41,7 +42,7 @@ class ComboLock:
         if not exists(self.path):
             f = open(self.path, 'w+')
             f.close()
-            chmod(self.path, 0o777)
+            chmod(self.path, LOCK_FILE_ACCESS_RIGHTS)
 
     def acquire(self, blocking=True):
         """ Acquire lock, locks thread and process lock.

--- a/combo_lock/util.py
+++ b/combo_lock/util.py
@@ -1,8 +1,17 @@
-import os
+from pathlib import Path
 import platform
 import tempfile
 
 from memory_tempfile import MemoryTempfile
+
+
+def make_dir_with_global_permissions(path):
+    """ Create directory and allow all to read/write to it. """
+    path = Path(path)  # Handle string input
+    if not path.exists():
+        path.mkdir(parents=True)
+        path.chmod(0o777)
+
 
 def get_ram_directory(folder):
     """ Fallback to a regular temp directory on unsupported platforms. """
@@ -10,7 +19,6 @@ def get_ram_directory(folder):
         temp_dir = MemoryTempfile(fallback=True).gettempdir()
     else:
         temp_dir = tempfile.gettempdir()
-    path = os.path.join(temp_dir, folder)
-    os.makedirs(path, exist_ok=True)
-    return path
-
+    path = Path(temp_dir, folder)
+    make_dir_with_global_permissions(path)
+    return str(path)

--- a/tests/test_named_lock.py
+++ b/tests/test_named_lock.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase
 
 from combo_lock import NamedLock
@@ -17,3 +18,11 @@ class TestNamedLock(TestCase):
         lock = NamedLock('💖🔒')
         with lock:
             pass
+
+    def test_named_lock_file_access_rights(self):
+        lock = NamedLock('access_rights_test_lock')
+        lock_path = Path(lock.path)
+        access_rights = 0o666
+        with lock:
+            pass
+        assert Path(lock_path).stat().st_mode & access_rights == access_rights

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest import TestCase
 
 from combo_lock.util import get_ram_directory
@@ -5,5 +6,7 @@ from combo_lock.util import get_ram_directory
 
 class TestComboLock(TestCase):
     def test_ram_dir(self):
-        ram_dir = get_ram_directory("combo_locks")
-        assert(ram_dir is not None)
+        ram_dir = get_ram_directory("test_combo_locks")
+        assert ram_dir is not None
+        access_rights = 0o777
+        assert Path(ram_dir).stat().st_mode & access_rights == access_rights


### PR DESCRIPTION
The rights for the created folder are set to 0o777 for to be readable and writable for all users.
The lock file lock is now initialized with an appropriate permission.

Should fix issue #21 